### PR TITLE
Add NOT FOUND label when no tests results found

### DIFF
--- a/robot.xsl
+++ b/robot.xsl
@@ -54,71 +54,92 @@
 </xsl:template>
 
 <xsl:template match="boards">
+  <!-- generate header from second board testsuites -->
+  <xsl:variable name="testsuite_headers" select="board[2]/testsuite/@name"/>
   <table class="table table-hover">
     <thead class="thead-light">
       <tr>
         <th class="border-right">Board</th>
-        <!-- generate header from first board testsuites -->
-        <xsl:for-each select="board[1]/testsuite">
-        <th><xsl:value-of select="@name" /></th>
+        <xsl:for-each select="$testsuite_headers">
+          <th>
+            <xsl:value-of select="." />
+          </th>
         </xsl:for-each>
       </tr>
     </thead>
     <tbody>
       <xsl:for-each select="board">
-      <tr>
-        <th class="border-right" scope="row">
-        <xsl:value-of select="@name" />
-        </th>
-        <xsl:for-each select="testsuite">
-          <xsl:variable name="board" select="../@name"/>
-          <xsl:variable name="suite" select="translate(@name,' ','_')"/>
-          <xsl:variable name="pass" select="@tests - @failures - @skipped"/>
-          <xsl:variable name="total" select="@tests"/>
-          <xsl:variable name="fails" select="@failures"/>
-          <xsl:variable name="skips" select="@skipped"/>
-          <xsl:variable name="pass_percent" select="$pass div $total * 100"/>
-          <xsl:variable name="fail_percent" select="$fails div $total * 100"/>
-          <xsl:variable name="skip_percent" select="$skips div $total * 100"/>
-          <td>
-            <a class="card-link" href="{$board}/{$suite}/report.html">
-              <!-- show list of failed and skipped tests in tooltip, if any -->
-              <xsl:if test="number($fails) &gt; 0 or number($skips) &gt; 0">
-                <xsl:attribute name="data-toggle">tooltip</xsl:attribute>
-                <xsl:attribute name="data-placement">bottom</xsl:attribute>
-                <xsl:attribute name="data-html">true</xsl:attribute>
-                <xsl:attribute name="title">
-                <xsl:if test="number($fails) &gt; 0">
-                  <xsl:value-of select="concat('Failed Tests:', '&#013;')" />
-                  <xsl:for-each select="testcase">
-                    <xsl:if test="failure">
-                      <xsl:value-of select="concat('- ', @name, '&#013;')" />
-                    </xsl:if>
-                  </xsl:for-each>
-                </xsl:if>
-                      <xsl:if test="number($skips) &gt; 0">
-                        <xsl:value-of select="concat('Skipped Tests:', '&#013;')" />
-                        <xsl:for-each select="testcase">
-                          <xsl:if test="skipped">
-                            <xsl:value-of select="concat('- ', @name, '&#013;')" />
-                          </xsl:if>
-                        </xsl:for-each>
-                      </xsl:if>
-                </xsl:attribute>
-              </xsl:if>
-              <div class="progress position-relative">
-                <div class="progress-bar bg-riot-green" role="progressbar" style="width: {$pass_percent}%" aria-valuenow="{$pass_percent}" aria-valuemin="0" aria-valuemax="100" />
-                <div class="progress-bar bg-riot-red" role="progressbar" style="width: {$fail_percent}%" aria-valuenow="{$fail_percent}" aria-valuemin="0" aria-valuemax="100" />
-                <div class="progress-bar bg-secondary" role="progressbar" style="width: {$skip_percent}%" aria-valuenow="{$skip_percent}" aria-valuemin="0" aria-valuemax="100" />
-                <bold class="justify-content-center d-flex position-absolute w-100 text-light">(<xsl:value-of select="$pass" />/<xsl:value-of select="$total" />)</bold>
-              </div>
-            </a>
-          </td>
-        </xsl:for-each>
-      </tr>
+        <xsl:variable name="board" select="current()"/>
+        <tr>
+          <th class="border-right" scope="row">
+            <xsl:value-of select="@name" />
+          </th>
+
+          <xsl:for-each select="$testsuite_headers">
+            <xsl:variable name="testsuite" select="$board/testsuite[@name = current()]"/>
+            <xsl:choose>
+              <xsl:when test="$testsuite/@name = current()">
+                <xsl:apply-templates select="$testsuite"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <td>
+                  <div class="text-center">NOT FOUND</div>
+                </td>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:for-each>
+        </tr>
       </xsl:for-each>
     </tbody>
   </table>
+</xsl:template>
+
+<xsl:template match="testsuite">
+  <xsl:variable name="board" select="../@name"/>
+  <xsl:variable name="suite" select="translate(@name,' ','_')"/>
+  <xsl:variable name="pass" select="@tests - @failures - @skipped"/>
+  <xsl:variable name="total" select="@tests"/>
+  <xsl:variable name="fails" select="@failures"/>
+  <xsl:variable name="skips" select="@skipped"/>
+  <xsl:variable name="pass_percent" select="$pass div $total * 100"/>
+  <xsl:variable name="fail_percent" select="$fails div $total * 100"/>
+  <xsl:variable name="skip_percent" select="$skips div $total * 100"/>
+  <td>
+    <a class="card-link" href="{$board}/{$suite}/report.html">
+      <!-- show list of failed and skipped tests in tooltip, if any -->
+      <xsl:if test="number($fails) &gt; 0 or number($skips) &gt; 0">
+        <xsl:attribute name="data-toggle">tooltip</xsl:attribute>
+        <xsl:attribute name="data-placement">bottom</xsl:attribute>
+        <xsl:attribute name="data-html">true</xsl:attribute>
+        <xsl:attribute name="title">
+          <xsl:if test="number($fails) &gt; 0">
+            <xsl:value-of select="concat('Failed Tests:', '&#013;')" />
+            <xsl:for-each select="testcase">
+              <xsl:if test="failure">
+                <xsl:value-of select="concat('- ', @name, '&#013;')" />
+              </xsl:if>
+            </xsl:for-each>
+          </xsl:if>
+          <xsl:if test="number($skips) &gt; 0">
+            <xsl:value-of select="concat('Skipped Tests:', '&#013;')" />
+            <xsl:for-each select="testcase">
+              <xsl:if test="skipped">
+                <xsl:value-of select="concat('- ', @name, '&#013;')" />
+              </xsl:if>
+            </xsl:for-each>
+          </xsl:if>
+        </xsl:attribute>
+      </xsl:if>
+      <div class="progress position-relative">
+        <div class="progress-bar bg-riot-green" role="progressbar" style="width: {$pass_percent}%" aria-valuenow="{$pass_percent}" aria-valuemin="0" aria-valuemax="100" />
+        <div class="progress-bar bg-riot-red" role="progressbar" style="width: {$fail_percent}%" aria-valuenow="{$fail_percent}" aria-valuemin="0" aria-valuemax="100" />
+        <div class="progress-bar bg-secondary" role="progressbar" style="width: {$skip_percent}%" aria-valuenow="{$skip_percent}" aria-valuemin="0" aria-valuemax="100" />
+        <bold class="justify-content-center d-flex position-absolute w-100 text-light">(          <xsl:value-of select="$pass" />
+/          <xsl:value-of select="$total" />
+)</bold>
+      </div>
+    </a>
+  </td>
 </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Adds a `NOT FOUND` label when no results for the testsuite are found.

#### Testing

To generate and tests this locally, follow the test instruction at #2.

#### Preview

Using the [`robot.xml` result](https://ci.riot-os.org/RIOT-OS/RIOT/master/4ceff67ca0b1e88abf8bdcb5e854d89146428c92/robot/robot.xml) from 27.04.2020

Without this PR:

![image](https://user-images.githubusercontent.com/20373062/81123167-b66db000-8f32-11ea-9f49-5713e46b1617.png)

With this PR:

![image](https://user-images.githubusercontent.com/20373062/81123113-9d64ff00-8f32-11ea-9efc-c8b0fe0a04df.png)
