### PR TITLE
xsl: Update to robot v4 syntax

### DIFF
--- a/xsl/main.xsl
+++ b/xsl/main.xsl
@@ -54,8 +54,8 @@
       <xsl:copy-of select="riot-error:raise-error('Missing param: page', 'yes')" />
     </xsl:if>
 
-    <xsl:variable name="current-board" select="/robot/suite/metadata/item[@name='RIOT-Board']" />
-    <xsl:variable name="current-testsuite" select="/robot/suite/metadata/item[@name='RIOT-Application']" />
+    <xsl:variable name="current-board" select="/robot/suite/meta[@name='RIOT-Board']" />
+    <xsl:variable name="current-testsuite" select="/robot/suite/meta[@name='RIOT-Application']" />
 
     <html lang="{$lang}" class="bg-white antialiased">
       <head>

--- a/xsl/pages/report.xsl
+++ b/xsl/pages/report.xsl
@@ -11,8 +11,8 @@
 
     <xsl:for-each select="$context-node">
 
-      <xsl:variable name="current-board" select="/robot/suite/metadata/item[@name='RIOT-Board']" />
-      <xsl:variable name="current-testsuite" select="/robot/suite/metadata/item[@name='RIOT-Application']" />
+      <xsl:variable name="current-board" select="/robot/suite/meta[@name='RIOT-Board']" />
+      <xsl:variable name="current-testsuite" select="/robot/suite/meta[@name='RIOT-Application']" />
 
       <div id="content" class="flex max-w-screen-xl mx-auto">
 

--- a/xsl/partials/statistics.xsl
+++ b/xsl/partials/statistics.xsl
@@ -48,23 +48,23 @@
     Aggregate 'test' results for each sub-suite and generates a table row.
   -->
   <xsl:template name="statistics-suite" match="suite/suite" mode="statistics">
-    <xsl:variable name="current-board" select="../metadata/item[@name='RIOT-Board']" />
-    <xsl:variable name="current-testsuite" select="../metadata/item[@name='RIOT-Application']" />
+    <xsl:variable name="current-board" select="../meta[@name='RIOT-Board']" />
+    <xsl:variable name="current-testsuite" select="../meta[@name='RIOT-Application']" />
 
     <xsl:variable name="pass">
-      <xsl:value-of select="count(./test/status[@status = 'PASS' and @critical = 'yes'])"/>
+      <xsl:value-of select="count(./test/status[@status = 'PASS'])"/>
     </xsl:variable>
 
     <xsl:variable name="fail">
-      <xsl:value-of select="count(./test/status[@status = 'FAIL' and @critical = 'yes'])"/>
-    </xsl:variable>
-
-    <xsl:variable name="total">
-      <xsl:value-of select="count(./test/status/@status)"/>
+      <xsl:value-of select="count(./test/status[@status = 'FAIL'])"/>
     </xsl:variable>
 
     <xsl:variable name="skips">
-      <xsl:value-of select="$total - $pass - $fail"/>
+      <xsl:value-of select="count(./test/status[@status = 'SKIP'])"/>
+    </xsl:variable>
+
+    <xsl:variable name="total">
+      <xsl:value-of select="$pass + $fail + $skips"/>
     </xsl:variable>
 
     <tr class="c-table-responsive-row">
@@ -104,19 +104,19 @@
   <xsl:template name="statistics-summary" match="suite" mode="statistics">
 
     <xsl:variable name="pass">
-      <xsl:value-of select="/robot/statistics/total/stat[text() = 'Critical Tests']/@pass" />
+      <xsl:value-of select="/robot/statistics/total/stat[text() = 'All Tests']/@pass" />
     </xsl:variable>
 
     <xsl:variable name="fail">
-      <xsl:value-of select="sum(/robot/statistics/total/stat[text() = 'Critical Tests']/@fail)" />
-    </xsl:variable>
-
-    <xsl:variable name="total">
-      <xsl:value-of select="sum(/robot/statistics/total/stat[text() = 'All Tests']/@*)" />
+      <xsl:value-of select="sum(/robot/statistics/total/stat[text() = 'All Tests']/@fail)" />
     </xsl:variable>
 
     <xsl:variable name="skips">
-      <xsl:value-of select="$total - $pass - $fail" />
+      <xsl:value-of select="sum(/robot/statistics/total/stat[text() = 'All Tests']/@skip)" />
+    </xsl:variable>
+
+    <xsl:variable name="total">
+      <xsl:value-of select="$pass + $fail + $skips" />
     </xsl:variable>
 
     <tr class="c-table-responsive-row">

--- a/xsl/partials/summary.xsl
+++ b/xsl/partials/summary.xsl
@@ -28,13 +28,13 @@
       <div class="w-full sm:w-1/2 flex order-2 sm:order-1 p-3">
         <table class="c-table-vertical c-table-hover text-left w-full table-auto border-collapse">
           <tbody>
-            <xsl:apply-templates mode="summary" select="/robot/suite/metadata/item[@name='RIOT-Board']">
+            <xsl:apply-templates mode="summary" select="/robot/suite/meta[@name='RIOT-Board']">
               <xsl:with-param name="title" select="'Board'" />
             </xsl:apply-templates>
-            <xsl:apply-templates mode="summary" select="/robot/suite/metadata/item[@name='RIOT-Application']">
+            <xsl:apply-templates mode="summary" select="/robot/suite/meta[@name='RIOT-Application']">
               <xsl:with-param name="title" select="'Testsuite'" />
             </xsl:apply-templates>
-            <xsl:apply-templates mode="summary" select="/robot/statistics/total/stat[text() = 'Critical Tests']">
+            <xsl:apply-templates mode="summary" select="/robot/statistics/total/stat[text() = 'All Tests']">
               <xsl:with-param name="title" select="'Status'" />
             </xsl:apply-templates>
             <xsl:apply-templates mode="summary" select="$metadata-doc/metadata/RIOT/commit_id">
@@ -81,7 +81,7 @@
   <!--
     Generate generic table row from text().
   -->
-  <xsl:template name="summary-row" match="item|commit_timestamp" mode="summary">
+  <xsl:template name="summary-row" match="meta|commit_timestamp" mode="summary">
     <xsl:param name="title" />
 
     <tr>
@@ -112,11 +112,11 @@
   </xsl:template>
 
   <!--
-    Generate table row from /robot/statistics/total/stat[text() = 'Critical Tests'].
+    Generate table row from /robot/statistics/total/stat[text() = 'All Tests'].
 
     Dont't use 'suite/status' as it is set to 'FAIL' even if skipped tasks fail!
   -->
-  <xsl:template name="summary-row-status" match="/robot/statistics/total/stat[text() = 'Critical Tests']" mode="summary">
+  <xsl:template name="summary-row-status" match="/robot/statistics/total/stat[text() = 'All Tests']" mode="summary">
     <xsl:param name="title" />
 
     <xsl:variable name="status">


### PR DESCRIPTION
Now that skip is part of Robot Framework version 4, some adaptations are needed.  Mostly just due to the critical tag.

The update needs to be coordinated over the Pi deployment and RobotFW-tests repo.